### PR TITLE
Throw error if Sauce Connect fails to start.

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -99,10 +99,7 @@ function download(options, callback) {
 
 function run(options, callback) {
   logger("Opening local tunnel using Sauce Connect");
-  var child = spawn("java", ["-jar", jarfile, options.username, options.accessKey]),
-    badExit = function () {
-      return callback(new Error("Could not start Sauce Connect."));
-    };
+  var child = spawn("java", ["-jar", jarfile, options.username, options.accessKey]);
 
   child.stdout.on("data", function (data) {
     var connectingText = 'Please wait for "You may start your tests" to start your tests',
@@ -129,6 +126,11 @@ function run(options, callback) {
     } else if (data.indexOf(errorText) !== -1) {
       logger("Sauce Connect Error");
       callback(new Error(data), child);
+    }
+  });
+  child.on('exit', function (code, signal) {
+    if (code > 0) {
+      callback(new Error("Could not start Sauce Connect. Exit code " + code));
     }
   });
 


### PR DESCRIPTION
Currently, badExit is unused and `child.on('exit')` is not listened to, so if Sauce Connect fails to start (invalid key, etc.) the program just hangs forever. This commit is a very simple hack to deal with non-zero exit codes.
