### PR TITLE
Made progress bar optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ var sauceConnectLauncher = require('sauce-connect-launcher'),
 		username: 'bermi',
 		accessKey: '12345678-1234-1234-1234-1234567890ab',
 		verbose: false,
-		logger: console.log
+		logger: console.log,
+		no_progress: false // optionally hide progress bar
 	};
 
 sauceConnectLauncher(options, function (err, sauceConnectProcess) {

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -52,16 +52,18 @@ function download(options, callback) {
     res.pipe(fs.createWriteStream(outfile));
 
     logger();
-    bar = new ProgressBar('  downloading Sauce-Connect-latest.zip [:bar] :percent :etas', {
-      complete: '=',
-      incomplete: ' ',
-      width: 20,
-      total: len
-    });
+    if (!options.no_progress) {
+      bar = new ProgressBar('  downloading Sauce-Connect-latest.zip [:bar] :percent :etas', {
+        complete: '=',
+        incomplete: ' ',
+        width: 20,
+        total: len
+      });
 
-    res.on('data', function (chunk) {
-      bar.tick(chunk.length);
-    });
+      res.on('data', function (chunk) {
+        bar.tick(chunk.length);
+      });
+    }
 
     res.on('end', function () {
       logger('\n');


### PR DESCRIPTION
Added a new option: `no_progress` .  This hides the display of the progress bar when downloading the launcher .zip.  This was causing issues when running this inside a child process and reading the stdout.
