### PR TITLE
Add support for tunnel identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var sauceConnectLauncher = require('sauce-connect-launcher'),
 		accessKey: '12345678-1234-1234-1234-1234567890ab',
 		verbose: false,
 		logfile: null, //optionally change sauce connect logfile location
+		tunnelIdentifier: null, // optionally identity the tunnel for concurrent tunnels
 		logger: console.log,
 		no_progress: false // optionally hide progress bar
 	};

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -112,6 +112,10 @@ function run(options, callback) {
     args.push('-l',options.logfile);
   }  
 
+  if (options.tunnelIdentifier) {
+    args.push('--tunnel-identifier', options.tunnelIdentifier);
+  }
+
   child = spawn("java", args);
   child.stdout.on("data", function (data) {
     var connectingText = 'Please wait for "You may start your tests" to start your tests',


### PR DESCRIPTION
Sauce Connnect added support for identifying tunnels. This allows
multiple concurrent tunnels within the same Sauce Labs account.

See:

https://saucelabs.com/opensource/travis
https://gist.github.com/santiycr/5139565
