### PR TITLE
Adds missing close callback.

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -190,7 +190,12 @@ function run(options, callback) {
 
   openProcesses.push(child);
 
-  child.close = function () {
+  child.close = function (closeCallback) {
+    if (closeCallback) {
+      child.on("close", function () {
+        closeCallback();
+      });
+    }
     child.kill("SIGTERM");
   };
 }

--- a/test/sauce-connect-launcher.test.js
+++ b/test/sauce-connect-launcher.test.js
@@ -90,6 +90,16 @@ describe("Sauce Connect Launcher", function () {
         done();
       });
     });
+
+    it("should execute a provided close callback", function (done) {
+      sauceConnectLauncher(sauceCreds, function (err, sauceConnectProcess) {
+        if (err) { throw err; }
+        expect(sauceConnectProcess).to.be.ok();
+        sauceConnectProcess.close(function () {
+          done();
+        });
+      });
+    });
   }
 
 });


### PR DESCRIPTION
In the latest version the example in the README is broken as the close callback was never executed. This PR adds a close callback.

``` javascript
sauceConnectProcess.close(function () {
  console.log("Closed Sauce Connect process");
});
```
