### PR TITLE
Fix reporting exit code 143 as an error closing Sauce Connect

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -180,6 +180,11 @@ function run(options, callback) {
   });
 
   child.on("exit", function (code, signal) {
+    // Java exits with code 143 on SIGTERM; this is not an error, it comes from child.close
+    if (code === 143) {
+      return;
+    }
+
     var message = "Closing Sauce Connect Tunnel";
     if (code > 0) {
       message = "Could not start Sauce Connect. Exit code " + code + " signal: " + signal;


### PR DESCRIPTION
In order to terminate Sauce Connect when `close` is called, a `SIGTERM` is sent to the child Java process. Java will receive the `SIGTERM`, shut down, and return an exit code of 143. This is not an error, so this pull request stops it from being reported as an error.
