### PR TITLE
extra checks for unreliable fs.watchFile()

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -165,7 +165,10 @@ function run(options, callback) {
   // Watching file as directory watching does not work on
   // all File Systems http://nodejs.org/api/fs.html#fs_caveats
   watcher = fs.watchFile(readyfile, {persistent: false}, function () {
-    ready();
+    fs.exists(readyfile, function (exists) {
+      if (exists)
+        ready();
+    })
   });
 
   watcher.on("error", callback);


### PR DESCRIPTION
`fs.watchFile` is a bit of a joke in terms of cross-platform reliability. I've added an `fs.exists()` check in there just to be sure that the file actually exists.
