### PR TITLE
Set execute permissions on sc binary after unpacking archive

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -90,6 +90,14 @@ function unpackArchive(callback) {
   }, 1000);
 }
 
+function setExecutePermissions(callback) {
+  logger("Setting execute permissions on " + getScBin());
+  fs.chmod(getScBin(), 0755, function (err) {
+    if (err) { return callback(new Error("Couldn't set permissions: " + err.message)); }
+    callback(null);
+  });
+}
+
 function download(options, callback) {
   var req = http.request({
       host: "saucelabs.com",
@@ -132,7 +140,10 @@ function download(options, callback) {
     }
 
     res.on("end", function () {
-      unpackArchive(done);
+      async.series([
+        unpackArchive,
+        setExecutePermissions
+      ], done);
     });
 
   });

--- a/test/sauce-connect-launcher.test.js
+++ b/test/sauce-connect-launcher.test.js
@@ -63,6 +63,7 @@ describe("Sauce Connect Launcher", function () {
         "This will only happen once.",
         "Downloading ",
         "Unzipping " + sauceConnectLauncher.getArchiveName(),
+        "Setting execute permissions ",
         "Removing " + sauceConnectLauncher.getArchiveName(),
         "Sauce Connect installed correctly",
         "Opening local tunnel using Sauce Connect",


### PR DESCRIPTION
I was just testing out sauce-connect-launcher for the Sauce Connect v4 support.
OS: Mac OS X 10.8.5

When executing the sc binary I was receiving EACCES errors.

  1) Sauce Connect Launcher should download Sauce Connect:
     Uncaught Error: spawn EACCES
      at errnoException (child_process.js:980:11)
      at Process.ChildProcess._handle.onexit (child_process.js:771:34)

Checking the permissions of the binary showed it did not have execute permissions:

$ ls -l sc/sc-4.0-osx/bin/sc
-rw-rw-rw-  1 bcbailey  ...  799324 Mar  3 11:20 sc/sc-4.0-osx/bin/sc

I have added in support to add execute permissions after extracting the archive. This resolves the issue. I am not sure if anything special needs to be done for windows though.
