### PR TITLE
Acquire Sauce Connect version on process run rather than import time,

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -16,8 +16,11 @@ var
   exists = fs.existsSync || path.existsSync,
   currentTunnel,
   logger = console.log,
-  cleanup_registered = false,
-  sc_version = process.env.SAUCE_CONNECT_VERSION || require("../package.json").sauceConnectLauncher.scVersion;
+  cleanup_registered = false;
+
+function getScVersion() {
+  return process.env.SAUCE_CONNECT_VERSION || require("../package.json").sauceConnectLauncher.scVersion;
+}
 
 function killProcesses(callback) {
   callback = callback || function () {};
@@ -43,6 +46,7 @@ function clean(callback) {
 }
 
 function getArchiveName() {
+  var sc_version = getScVersion();
   return {
     darwin: "sc-" + sc_version + "-osx.zip",
     win32: "sc-" + sc_version + "-win32.zip"
@@ -50,6 +54,7 @@ function getArchiveName() {
 }
 
 function getScFolderName() {
+  var sc_version = getScVersion();
   return {
     darwin: "sc-" + sc_version + "-osx",
     win32: "sc-" + sc_version + "-win32"


### PR DESCRIPTION
to allow SAUCE_CONNECT_VERSION to be redefined from grunt-env.
Without this change the grunt-env settings would not have an effect.

I needed this because I wanted to run Sauce Connect 4.2 to check if it solves some tunnel problems. The package is currently fixed to 4.1. But it can be useful in general that one can set this variable from grunt-env, from the Gruntfile.js only.
