### PR TITLE
setting permissions after download

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -325,13 +325,12 @@ function downloadAndStartProcess(options, callback) {
   async.waterfall([
     function checkForBinary(next) {
       if (exists(getScBin())) {
-        setExecutePermissions(function () {
-          next(null);
-        });
+        next(null);
       } else {
         checkForArchive(next);
       }
     },
+    async.apply(setExecutePermissions),
     async.apply(run, options)
   ], callback);
 


### PR DESCRIPTION
`setExecutePermissions` was not called after `checkForArchive`
