### PR TITLE
Upgrade package to 4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "node": ">= 0.10.x"
   },
   "sauceConnectLauncher": {
-    "scVersion": "4.2"
+    "scVersion": "4.3"
   }
 }


### PR DESCRIPTION
Is there any reason why the default is still 4.2? Sauce Connect outputs a warning prompting to use 4.3.

This PR just updates the default version to 4.3
