### PR TITLE
New verboseDebugging flag to pass --verbose to sc

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ var sauceConnectLauncher = require('sauce-connect-launcher'),
     // Log output from the `sc` process to stdout?
     verbose: false,
 
+    // Enable verbose debugging (optional)
+    verboseDebugging: false,
+
     // Port on which Sauce Connect's Selenium relay will listen for
     // requests. Default 4445. (optional)
     port: null

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -230,6 +230,10 @@ function run(options, callback) {
     args.push("--fast-fail-regexps", options.fastFailRegexps);
   }
 
+  if (options.verboseDebugging) {
+    args.push("--verbose");
+  }
+
   if (options.logfile) {
     args.push("-l", options.logfile);
   }


### PR DESCRIPTION
I explicitly didn't reuse the `verbose` option, which already seems to be in use for a different purpose (logging to stdout, rather than verbose sauce-connect logging). Let me know if you want the same option to be used for both?
