### PR TITLE
add quotation to an argument of tar command

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -82,7 +82,7 @@ function unpackArchive(callback) {
   logger("Unzipping " + getArchiveName());
   setTimeout(function () {
     if (archivefile.match(/\.tar\.gz$/)) {
-      exec("tar -xf " + archivefile, {cwd: scDir}, callback);
+      exec("tar -xf '" + archivefile + "'", {cwd: scDir}, callback);
     } else {
       try {
         var zip = new AdmZip(archivefile);


### PR DESCRIPTION
To deal with the case that `archivefile` path contains spaces, add quotation to an argument of `tar` command.

In my case, I have used this module by jenkins. And that project name had spaces. So the path to tar.gz file has contained spaces.
