### PR TITLE
fix(install): use prepublish script rather than install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/bermi/sauce-connect-launcher"
   },
   "scripts": {
-    "install": "node scripts/install.js",
+    "prepublish": "node scripts/install.js",
     "test": "make test"
   },
   "dependencies": {


### PR DESCRIPTION
---

please note: I wasn't able to run the tests due to a missing devDependency, but I've verified that with this change allows me to install sauce-connect-launcher@1.7.0 even while depending on lodash directly.  commit message copied below

---

scripts/install.js requires lodash (and other modules), but if they are
direct dependencies of an application then they may not be available
when the `install` step runs in npm.

Convert from running the script as an `install` script to a `prepublish`
script so that other application dependencies are available at the time
it runs.

Closes #37
