### PR TITLE
optional readyFile suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ var sauceConnectLauncher = require('sauce-connect-launcher'),
 
     // A function to optionally write sauce-connect-launcher log messages.
     // e.g. `console.log`.  (optional)
-    logger: function (message) {}
+    logger: function (message) {},
+
+    // an optional suffix to be appended to the `readyFile` name.
+    // useful when running multiple tunnels on the same machine,
+    // such as in a continuous integration environment. (optional)
+    readyFileId: null
   };
 
 sauceConnectLauncher(options, function (err, sauceConnectProcess) {

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -11,8 +11,6 @@ var
   exec = require("child_process").exec,
   archivefile,
   scDir = path.normalize(__dirname + "/../sc"),
-  // Node v0.8 uses os.tmpDir(), v0.10 uses os.tmpdir()
-  readyfile = path.normalize((os.tmpdir ? os.tmpdir() : os.tmpDir()) + "/sc-launcher-readyfile"),
   exists = fs.existsSync || path.existsSync,
   currentTunnel,
   logger = console.log,
@@ -212,6 +210,7 @@ function run(options, callback) {
   logger("Opening local tunnel using Sauce Connect");
   var child,
     watcher,
+    readyFileName = "sc-launcher-readyfile",
     args = [
       "-u", options.username || process.env.SAUCE_USERNAME,
       "-k", options.accessKey || process.env.SAUCE_ACCESS_KEY
@@ -285,6 +284,14 @@ function run(options, callback) {
   if (options.tunnelIdentifier) {
     args.push("--tunnel-identifier", options.tunnelIdentifier);
   }
+
+  if (options.readyFileId) {
+    readyFileName = readyFileName + "_" + options.readyFileId;
+  }
+
+  // Node v0.8 uses os.tmpDir(), v0.10 uses os.tmpdir()
+  readyfile = path.normalize((os.tmpdir ? os.tmpdir() : os.tmpDir())
+    + "/" + readyFileName),
 
   args.push("--readyfile", readyfile);
 


### PR DESCRIPTION
Fixes https://github.com/bermi/sauce-connect-launcher/issues/39

Usage:  specifying `readyFileId: "123"` results in readyFile being created as `[temp-directory]/sc-launcher-readyfile_123`

In our CI environment we pass the build ID as the `readyFileId` so that multiple builds on the same worker box won't conflict with each other.
