### PR TITLE
handle errors reported as JSON, `{"error":...`

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -217,6 +217,16 @@ function run(options, callback) {
       "-k", options.accessKey || process.env.SAUCE_ACCESS_KEY
     ],
     error,
+    handleError = function (data) {
+      if (data.indexOf("Not authorized") !== -1 && !error) {
+        logger("Invalid Sauce Connect Credentials");
+        error = new Error("Invalid Sauce Connect Credentials. " + data);
+      } else if (data.indexOf("HTTP response code indicated failure") === -1) {
+        // sc says the above before it says "Not authorized", but the following
+        // Error: message is more useful
+        error = new Error(data);
+      }
+    },
     dataActions = {
       "Please wait for 'you may start your tests' to start your tests": function connecting() {
         logger("Creating tunnel with Sauce Labs");
@@ -225,16 +235,8 @@ function run(options, callback) {
       "This version of Sauce Connect is outdated": function outdated() {
 
       },
-      "Error: ": function handleError(data) {
-        if (data.indexOf("Not authorized") !== -1 && !error) {
-          logger("Invalid Sauce Connect Credentials");
-          error = new Error("Invalid Sauce Connect Credentials. " + data);
-        } else if (data.indexOf("HTTP response code indicated failure") === -1) {
-          // sc says the above before it says "Not authorized", but the following
-          // Error: message is more useful
-          error = new Error(data);
-        }
-      },
+      "Error: ": handleError,
+      "{\"error\":": handleError,
       "Goodbye.": function shutDown() {
 
       }


### PR DESCRIPTION
At least on OS X, the current version of sc is reporting credentials
errors as:

`Response: {"error": "Not authorized"}.`

Break out error handling function and apply it to existing string as
well as the string `"{\"error\":"`.
