### PR TITLE
fixes bermi/sauce-connect-launcher#58

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -329,8 +329,8 @@ function downloadAndRun(options, callback) {
 
   async.waterfall([
     async.apply(download, options),
-    async.apply(run, options),
-  ], callback);
+    async.apply(run, options, callback),
+  ]);
 }
 
 archivefile = path.normalize(scDir + "/" + getArchiveName());


### PR DESCRIPTION
trigger callback when tunnel is ready 
(tunnel is up and running with pid file set) and not allready when the sc executable is called

fixes: https://github.com/bermi/sauce-connect-launcher/issues/58