### PR TITLE
Fix incorrect equality operator

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -220,12 +220,12 @@ function run(options, callback) {
       if (data.indexOf("Not authorized") !== -1 && !error) {
         logger("Invalid Sauce Connect Credentials");
         error = new Error("Invalid Sauce Connect Credentials. " + data);
+      } else if (data.indexOf("Sauce Connect could not establish a connection") !== -1) {
+        logger("Sauce Connect API failure");
+        error = new Error(data);
       } else if (data.indexOf("HTTP response code indicated failure") === -1) {
         // sc says the above before it says "Not authorized", but the following
         // Error: message is more useful
-        error = new Error(data);
-      } else if (data.indexOf("Sauce Connect could not establish a connection") === -1) {
-        logger("Sauce Connect API failure");
         error = new Error(data);
       }
       // error will be handled in the child.on("exit") handler


### PR DESCRIPTION
In a [previous fix](https://github.com/bermi/sauce-connect-launcher/pull/54) for handling an unhandled error, I used the `===` operator when I should have used the `!==` operator.  This is because I had lazily copy/pasted from an `else if` block that I believed was doing the same thing (but was actually checking that a string was _not_ present)

Shame on me. :disappointed: 

This PR:

1. Fixes the incorrect `===` operator to `!==` so that we're ensuring the index of the substring is NOT `-1` (which would indicate it does not exist)
2. Moves my condition up one position in the if/else block to group it with the similar condition above.

Tested this condition locally and verified that it correctly errors out now when `Sauce Connect could not establish a connection` is output in the sauce connect logs.