### PR TITLE
Unwatch readyfile when no longer needed

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -273,7 +273,7 @@ function run(options, callback) {
 
   // Watching file as directory watching does not work on
   // all File Systems http://nodejs.org/api/fs.html#fs_caveats
-  watcher = fs.watchFile(readyfile, {persistent: false}, function () {
+  watcher = fs.watchFile(readyfile, function () {
     fs.exists(readyfile, function (exists) {
       if (exists) {
         logger("Detected sc ready");
@@ -310,6 +310,8 @@ function run(options, callback) {
 
   child.on("exit", function (code, signal) {
     currentTunnel = null;
+
+    fs.unwatchFile(readyfile);
 
     if (error) { // from handleError() above
       return callback(error);


### PR DESCRIPTION
Prevents double ready callbacks when starting multiple tunnels
