### PR TITLE
Update Sauce Connect to 4.3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "node": ">= 0.10.x"
   },
   "sauceConnectLauncher": {
-    "scVersion": "4.3.11"
+    "scVersion": "4.3.12"
   }
 }


### PR DESCRIPTION
A newer version of Sauce Connect (build 1789) is available!