### PR TITLE
fix: support older versions of tar with `xzf` flag

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -82,7 +82,7 @@ function unpackArchive(callback) {
   logger("Unzipping " + getArchiveName());
   setTimeout(function () {
     if (archivefile.match(/\.tar\.gz$/)) {
-      exec("tar -xf '" + archivefile + "'", {cwd: scDir}, callback);
+      exec("tar -xzf '" + archivefile + "'", {cwd: scDir}, callback);
     } else {
       try {
         var zip = new AdmZip(archivefile);


### PR DESCRIPTION
Older version of tar, or lighter weight versions (e.g. the tar in BusyBox v1.23.2) do not support
using tar with the `xf` flags - making tar guess what file format the archive is.

We are already asserting that the file is of type of `.tar.gz` so we can safely assume this is a gzip
archive. Adding the `z` flag will support older versions of `tar` while still being fully compatible with
new versions.

Use case: attempting to use sauce-connect-launcher in an Alpine Linux Docker Container, with
BusyBox v1.23.2 - which does not support `tar xf`, giving the error `tar: invalid tar magic`