### PR TITLE
Add http proxy support for download

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -6,6 +6,7 @@ var
   _ = require("lodash"),
   async = require("async"),
   https = require("https"),
+  HttpsProxyAgent = require('https-proxy-agent'),
   AdmZip = require("adm-zip"),
   spawn = require("child_process").spawn,
   exec = require("child_process").exec,
@@ -117,7 +118,16 @@ function setExecutePermissions(callback) {
 }
 
 function fetchAndUnpack(options, callback) {
+  // Optional http proxy to route the download through
+  // (if agent is undefined, https.request will proceed as normal)
+  var proxy = process.env.https_proxy || process.env.http_proxy;
+  var agent;
+  if (proxy) {
+    agent = new HttpsProxyAgent(proxy);
+  }
+
   var req = https.request({
+      agent: agent,
       host: "saucelabs.com",
       port: 443,
       path: "/downloads/" + getArchiveName()

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lodash": "3.10.1",
     "async": "1.4.0",
     "adm-zip": "~0.4.3",
+    "https-proxy-agent": "~1.0.0",
     "rimraf": "2.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds support for specifying an http proxy via `http_proxy` or `https_proxy` in the environment. If not specified, no proxy is used (ie. the current behavior).

This is handy for environments where routing internet traffic via a proxy is needed, and seems like it would solve #26.