### PR TITLE
Fix download problems with corporate proxy

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -125,8 +125,8 @@ function fetchAndUnpack(options, callback) {
   };
   var proxy = process.env.http_proxy;
   if (proxy !== undefined) {
-    logger("Using proxy server " + proxy);
     requestOptions.agent = new httpsProxyAgent(proxy);
+    logger("http_proxy settings found and proxy agent taken into use");
   }
   var req = https.request(requestOptions);
 

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -123,10 +123,10 @@ function fetchAndUnpack(options, callback) {
     port: 443,
     path: "/downloads/" + getArchiveName()
   };
-  var proxy = process.env.http_proxy;
+  var proxy = process.env.https_proxy || process.env.http_proxy;
   if (proxy !== undefined) {
     requestOptions.agent = new httpsProxyAgent(proxy);
-    logger("http_proxy settings found and proxy agent taken into use");
+    logger("http(s) proxy settings found and proxy agent is taken into use");
   }
   var req = https.request(requestOptions);
 

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -7,6 +7,7 @@ var
   async = require("async"),
   https = require("https"),
   AdmZip = require("adm-zip"),
+  httpsProxyAgent = require("https-proxy-agent"),
   spawn = require("child_process").spawn,
   exec = require("child_process").exec,
   processOptions = require("./process_options"),
@@ -117,11 +118,17 @@ function setExecutePermissions(callback) {
 }
 
 function fetchAndUnpack(options, callback) {
-  var req = https.request({
-      host: "saucelabs.com",
-      port: 443,
-      path: "/downloads/" + getArchiveName()
-    });
+  var requestOptions = {
+    host: "saucelabs.com",
+    port: 443,
+    path: "/downloads/" + getArchiveName()
+  };
+  var proxy = process.env.http_proxy;
+  console.log("Using proxy server " + proxy);
+  if (proxy !== undefined) {
+    requestOptions.agent = new httpsProxyAgent(proxy);
+  }
+  var req = https.request(requestOptions);
 
   function removeArchive() {
     try {

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -124,8 +124,8 @@ function fetchAndUnpack(options, callback) {
     path: "/downloads/" + getArchiveName()
   };
   var proxy = process.env.http_proxy;
-  console.log("Using proxy server " + proxy);
   if (proxy !== undefined) {
+    logger("Using proxy server " + proxy);
     requestOptions.agent = new httpsProxyAgent(proxy);
   }
   var req = https.request(requestOptions);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lodash": "3.10.1",
     "async": "1.4.0",
     "adm-zip": "~0.4.3",
-    "rimraf": "2.4.3"
+    "rimraf": "2.4.3",
+    "https-proxy-agent": "1.0.0"
   },
   "devDependencies": {
     "colors": "~1.1.2",


### PR DESCRIPTION
If corporate proxy is used, ```npm install wct-sauce``` fails, because ```sauce-connect-launcher``` does not respect proxy settings in https.request to saucelabs.com , as described in https://github.com/Polymer/wct-sauce/issues/5 and https://github.com/Polymer/web-component-tester/issues/140.

This fix should solve https://github.com/bermi/sauce-connect-launcher/issues/26 . It will use ```https-proxy-agent``` for https request, if ```https_proxy``` or ```http_proxy```environment variable is set. If not, request will work as before.