### PR TITLE
Support install with nodejs on standard Debian/Ubuntu-Systems, too.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/bermi/sauce-connect-launcher"
   },
   "scripts": {
-    "postinstall": "node scripts/install.js",
+    "postinstall": "node scripts/install.js || nodejs scripts/install.js",
     "test": "make test"
   },
   "dependencies": {


### PR DESCRIPTION
On Debian and Ubuntu systems the node binary is named nodejs instead of node 8-(
This patch supports both ways to invoke node.

Today installing sauce-connect-launcher fails with:

    > sauce-connect-launcher@0.13.0 postinstall /home/leutloff/node_modules/sauce-connect-launcher
    > node scripts/install.js
    
    sh: 1: node: not found

This changed is derived from fibers (https://github.com/laverdet/node-fibers/blob/master/package.json).
