### PR TITLE
Auto-resolve latest versions and verify checksum

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -10,21 +10,21 @@ var
   AdmZip = require("adm-zip"),
   spawn = require("child_process").spawn,
   exec = require("child_process").exec,
+  crypto = require("crypto"),
   processOptions = require("./process_options"),
+  versionsfile,
   archivefile,
   scDir = path.normalize(__dirname + "/../sc"),
   exists = fs.existsSync || path.existsSync,
   currentTunnel,
   logger = console.log,
-  cleanup_registered = false;
+  cleanup_registered = false,
+  sc_version = process.env.SAUCE_CONNECT_VERSION ||
+    require("../package.json").sauceConnectLauncher.scVersion,
+  sc_checksum;
 
 function setWorkDir(workDir) {
   scDir = workDir;
-}
-
-function getScVersion() {
-  return process.env.SAUCE_CONNECT_VERSION ||
-    require("../package.json").sauceConnectLauncher.scVersion;
 }
 
 function killProcesses(callback) {
@@ -51,7 +51,6 @@ function clean(callback) {
 }
 
 function getArchiveName() {
-  var sc_version = getScVersion();
   return {
     darwin: "sc-" + sc_version + "-osx.zip",
     win32: "sc-" + sc_version + "-win32.zip"
@@ -59,7 +58,6 @@ function getArchiveName() {
 }
 
 function getScFolderName() {
-  var sc_version = getScVersion();
   return {
     darwin: "sc-" + sc_version + "-osx",
     win32: "sc-" + sc_version + "-win32"
@@ -121,7 +119,7 @@ function setExecutePermissions(callback) {
   }
 }
 
-function fetchAndUnpack(options, callback) {
+function httpsRequest(options) {
   // Optional http proxy to route the download through
   // (if agent is undefined, https.request will proceed as normal)
   var proxy = process.env.https_proxy || process.env.http_proxy;
@@ -130,8 +128,33 @@ function fetchAndUnpack(options, callback) {
     agent = new HttpsProxyAgent(proxy);
   }
 
-  var req = https.request({
-      agent: agent,
+  options = options || {};
+  options.agent = agent;
+
+  return https.request(options);
+}
+
+function verifyChecksum(cb) {
+  var fd = fs.createReadStream(archivefile);
+  var hash = crypto.createHash("sha1");
+  hash.setEncoding("hex");
+
+  hash.on("end", function() {
+    hash.end();
+
+    var sha1 = hash.read();
+    if (sha1 !== sc_checksum) {
+      cb(new Error("Checksum of the downloaded archive (" + sha1 + ") doesn't match (" + sc_checksum + ")."));
+    }
+
+    cb();
+  });
+
+  fd.pipe(hash);
+}
+
+function fetchAndUnpack(options, callback) {
+  var req = httpsRequest({
       host: "saucelabs.com",
       port: 443,
       path: "/downloads/" + getArchiveName()
@@ -172,7 +195,72 @@ function fetchAndUnpack(options, callback) {
     }
 
     res.on("end", function () {
+      if (sc_checksum) {
+        async.waterfall([
+          async.apply(verifyChecksum),
+          async.apply(unpackArchive),
+        ], done);
+      }
+
       unpackArchive(done);
+    });
+
+  });
+
+  req.end();
+}
+
+function scPlatform() {
+  return {
+    darwin: "osx",
+    win32: "win32",
+  }[process.platform] || "linux";
+}
+
+function getVersions(cb) {
+  function done(err) {
+    if (err) {
+      return cb(err);
+    }
+
+    var versions = require(versionsfile)["Sauce Connect"];
+
+    sc_version = versions["version"];
+    sc_checksum = versions[scPlatform()]["sha1"];
+
+    return cb();
+  }
+
+  if (sc_version !== "latest") {
+    logger("Checksum check for manually overwritten sc versions isn't supported.");
+    return done();
+  }
+
+  if (exists(versionsfile)) {
+    return done();
+  }
+
+  var req = httpsRequest({
+      host: "saucelabs.com",
+      port: 443,
+      path: "/versions.json"
+    });
+
+  req.on("response", function (res) {
+    if (res.statusCode !== 200) {
+      return done(new Error("Fetching https://saucelabs.com/versions.json failed: " + res.statusCode));
+    }
+
+    var file = fs.createWriteStream(versionsfile);
+
+    res.pipe(file);
+
+    file.on("error", function (err) {
+      done(err);
+    });
+
+    file.on("close", function () {
+      done();
     });
 
   });
@@ -203,6 +291,7 @@ function download(options, callback) {
   }
 
   async.waterfall([
+    getVersions,
     function checkForBinary(next) {
       if (exists(getScBin())) {
         next(null);
@@ -347,6 +436,7 @@ function downloadAndRun(options, callback) {
   ], callback);
 }
 
+versionsfile = path.normalize(scDir + "/versions.json");
 archivefile = path.normalize(scDir + "/" + getArchiveName());
 
 module.exports = downloadAndRun;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "node": ">= 0.10.x"
   },
   "sauceConnectLauncher": {
-    "scVersion": "4.4.1"
+    "scVersion": "latest"
   }
 }


### PR DESCRIPTION
Replaces the hardcoded version with auto-resolving the latest version
from https://saucelabs.com/versions.json and also using the provided
checksums to verify the downloaded archive.

Fixes https://github.com/bermi/sauce-connect-launcher/issues/70