### PR TITLE
Hide api key when printing sc arguments

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -404,6 +404,7 @@ function connect(options, callback) {
   logger("Starting sc with args: " + args
     .join(" ")
     .replace(/-u\ [^\ ]+\ /, "-u XXXXXXXX ")
+    .replace(/-k\ [^\ ]+\ /, "-k XXXXXXXX ")
     .replace(/[0-9a-f]{8}\-([0-9a-f]{4}\-){3}[0-9a-f]{12}/i,
       "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX"));
 


### PR DESCRIPTION
The api key is private and shouldn't be displayed.

Fixes https://github.com/bermi/sauce-connect-launcher/issues/91
