### PR TITLE
Allow to provide a custom executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ var sauceConnectLauncher = require('sauce-connect-launcher'),
 
     // time to wait between connection retries in ms. (optional)
     connectRetryTimeout: 5000
+
+    // path to a sauce connect executable (optional)
+    // by default the latest sauce connect version is downloaded
+    exe: null
   };
 
 sauceConnectLauncher(options, function (err, sauceConnectProcess) {

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -283,6 +283,10 @@ function download(options, callback) {
   }
   logger = options.logger || function () {};
 
+  if (options.exe) {
+    return callback(null);
+  }
+
   if (!fs.existsSync(scDir)) {
     fs.mkdirSync(scDir);
   }
@@ -312,6 +316,7 @@ function download(options, callback) {
 }
 
 function connect(options, callback) {
+  var child;
   var logger = options.logger || function () {};
   callback = _.once(callback);
 
@@ -322,8 +327,7 @@ function connect(options, callback) {
   }
 
   logger("Opening local tunnel using Sauce Connect");
-  var child,
-    watcher,
+  var watcher,
     readyfile,
     readyFileName = "sc-launcher-readyfile",
     args = processOptions(options),
@@ -407,7 +411,14 @@ function connect(options, callback) {
     .replace(/[0-9a-f]{8}\-([0-9a-f]{4}\-){3}[0-9a-f]{12}/i,
       "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX"));
 
-  child = spawn(getScBin(), args);
+  var exe;
+  if (options.exe) {
+    exe = options.exe;
+  } else {
+    exe = getScBin();
+  }
+
+  child = spawn(exe, args);
 
   currentTunnel = child;
 

--- a/test/sauce-connect-launcher.test.js
+++ b/test/sauce-connect-launcher.test.js
@@ -128,7 +128,7 @@ describe("Sauce Connect Launcher", function () {
                 expect(body.status).to.eql("terminated");
                 done();
               });
-            }, 1000);
+            }, 3000);
           });
         });
       });


### PR DESCRIPTION
Instead of downloading the latest sc, allow to provide a custom
binary.

Fixes https://github.com/bermi/sauce-connect-launcher/issues/75