### PR TITLE
Configurable connection retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ var sauceConnectLauncher = require('sauce-connect-launcher'),
     // an optional suffix to be appended to the `readyFile` name.
     // useful when running multiple tunnels on the same machine,
     // such as in a continuous integration environment. (optional)
-    readyFileId: null
+    readyFileId: null,
+
+    // retry to establish a tunnel multiple times. (optional)
+    connectRetries: 0
+
+    // time to wait between connection retries in ms. (optional)
+    connectRetryTimeout: 5000
   };
 
 sauceConnectLauncher(options, function (err, sauceConnectProcess) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 
 # Post-install test scripts.
 test_script:
-  - appveyor-retry npm test
+  - npm test
 
 # Don't actually build.
 build: off

--- a/lib/process_options.js
+++ b/lib/process_options.js
@@ -17,7 +17,7 @@ module.exports = function processOptions(options) {
   options.accessKey = options.accessKey || process.env.SAUCE_ACCESS_KEY;
 
   return _.reduce(
-    _.omit(options, ["readyFileId", "verbose", "logger", "log"]),
+    _.omit(options, ["readyFileId", "verbose", "logger", "log", "connectRetries", "connectRetryTimeout"]),
     function (argList, value, key) {
       if (value == null) {
         return argList;

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -23,7 +23,8 @@ var
     require("../package.json").sauceConnectLauncher.scVersion,
   sc_checksum,
   tunnelIdRegExp = /Tunnel ID:\s*([a-z0-9]+)/i,
-  portRegExp = /port\s*([0-9]+)/i;
+  portRegExp = /port\s*([0-9]+)/i,
+  tryRun = require("./try_run");
 
 function setWorkDir(workDir) {
   scDir = workDir;
@@ -310,7 +311,7 @@ function download(options, callback) {
   ], callback);
 }
 
-function run(options, callback) {
+function connect(options, callback) {
   var logger = options.logger || function () {};
   callback = _.once(callback);
 
@@ -482,6 +483,13 @@ function run(options, callback) {
       killProcess();
     }
   };
+}
+
+
+
+
+function run(options, callback) {
+  tryRun(0, options, connect, callback);
 }
 
 function downloadAndRun(options, callback) {

--- a/lib/try_run.js
+++ b/lib/try_run.js
@@ -1,0 +1,17 @@
+var defaultConnectRetryTimeout = 2000;
+
+module.exports = function tryRun(count, options, fn, callback) {
+  fn(options, function (err, result) {
+    if (err) {
+      if (count < options.connectRetries) {
+        return setTimeout(function () {
+          tryRun(count + 1, options, fn, callback);
+        }, options.connectRetryTimeout || defaultConnectRetryTimeout);
+      }
+
+      return callback(err);
+    }
+
+    callback(null, result);
+  });
+};

--- a/test/process_options.test.js
+++ b/test/process_options.test.js
@@ -64,7 +64,9 @@ describe("processOptions", function () {
     expect(processOptions({
       readyFileId: "1",
       verbose: true,
-      logger: function () {}
+      logger: function () {},
+      connectRetries: 1,
+      connectRetryTimeout: 5000
     })).to.eql([]);
   });
 

--- a/test/sauce-connect-launcher.test.js
+++ b/test/sauce-connect-launcher.test.js
@@ -21,6 +21,7 @@ try {
     }
     sauceCreds.log.push(message);
   };
+  sauceCreds.connectRetries = 3;
 } catch (e) {
   require("colors");
   console.log("Please run make setup-sauce to set up real Sauce Labs Credentials".red);

--- a/test/try_run_test.js
+++ b/test/try_run_test.js
@@ -1,0 +1,64 @@
+var tryRun = require("../lib/try_run");
+var expect = require("expect.js");
+
+describe("tryRun", function () {
+  var innerErr = new Error("Inner function failed");
+
+  describe("without configured retry", function () {
+    it("calls the provided function once", function (done) {
+      var innerCalls = 0;
+      tryRun(0, {}, function (options, callback) {
+        innerCalls += 1;
+        callback(innerErr);
+      }, function (err) {
+        expect(err).to.equal(innerErr);
+        done();
+      });
+    });
+  });
+
+  describe("with configured retry", function () {
+    var retryTimeout = 10;
+    var retryOptions = {
+      connectRetries: 2,
+      connectRetryTimeout: retryTimeout
+    };
+
+    it("calls the provided function once when no error is returned", function (done) {
+      var innerCalls = 0;
+      tryRun(0, retryOptions, function (options, callback) {
+        innerCalls += 1;
+        callback(null);
+      }, function (err) {
+        expect(err).to.not.be.ok();
+        expect(innerCalls).to.be(1);
+        done();
+      });
+    });
+
+    it("retries up-to connectRetries when the function returns an error", function (done) {
+      var innerCalls = 0;
+      tryRun(0, retryOptions, function (options, callback) {
+        innerCalls += 1;
+        callback(innerErr);
+      }, function (err) {
+        expect(err).to.equal(innerErr);
+        expect(innerCalls).to.be(3);
+        done();
+      });
+    });
+
+    it("waits connectRetryTimeout between retries", function (done) {
+      var innerCalls = 0;
+      var start = Date.now();
+      tryRun(0, retryOptions, function (options, callback) {
+        innerCalls += 1;
+        callback(innerErr);
+      }, function () {
+        var end = Date.now();
+        expect(end - start).greaterThan(19); // Double timeout-1
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Allow to retry tunnel creation multiple times with a configurable
timeout between retries.

@henryprecheur @jlipps any objections, feedback?

This has been requested by some ember folks and might also workaround the flakiness in the tests of this module.