### PR TITLE
Remove support for Node 0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@
 language: node_js
 sudo: false
 node_js:
-- "0.10"
-- "0.12"
-- 4
-- 6
+- '4'
+- '6'
+- '7'
 env:
   global:
   - SAUCE_USERNAME=sc-launcher-ci

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -134,6 +134,7 @@ function httpsRequest(options) {
 
   options = options || {};
   options.agent = agent;
+  options.timeout = 30000;
 
   return https.request(options);
 }
@@ -445,6 +446,13 @@ function connect(options, callback) {
     });
   });
 
+  child.on("error", function (err) {
+    logger("Sauce connect process errored: " + err);
+
+    fs.unwatchFile(readyfile);
+    return callback(err);
+  });
+
   child.on("exit", function (code, signal) {
     currentTunnel = null;
     child = null;
@@ -470,7 +478,7 @@ function connect(options, callback) {
 
   child.close = function (closeCallback) {
     if (closeCallback) {
-      child.on("close", function () {
+      child.on("exit", function () {
         closeCallback();
       });
     }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://github.com/bermi/sauce-connect-launcher",
   "author": "Bermi Ferrer <bermi@bermilabs.com>",
   "main": "lib/sauce-connect-launcher",
+  "license": "MIT",
   "keywords": [
     "selenium",
     "sauce connect",
@@ -40,7 +41,7 @@
     "mocha": "~2.3.3"
   },
   "engines": {
-    "node": ">= 0.10.x"
+    "node": ">= 4"
   },
   "sauceConnectLauncher": {
     "scVersion": "latest"

--- a/package.json
+++ b/package.json
@@ -22,23 +22,23 @@
     "test": "make test"
   },
   "dependencies": {
-    "lodash": "3.10.1",
-    "async": "1.4.0",
     "adm-zip": "~0.4.3",
+    "async": "^2.1.2",
     "https-proxy-agent": "~1.0.0",
-    "rimraf": "2.4.3"
+    "lodash": "^4.16.6",
+    "rimraf": "^2.5.4"
   },
   "devDependencies": {
     "colors": "~1.1.2",
     "expect.js": "~0.3.1",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
-    "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-jshint": "~0.11.0",
+    "grunt-contrib-watch": "~0.6.1",
     "grunt-notify": "~0.4.0",
     "grunt-release": "~0.13.0",
     "grunt-simple-mocha": "~0.4.0",
-    "mocha": "~2.3.3"
+    "mocha": "^3.1.2"
   },
   "engines": {
     "node": ">= 4"

--- a/test/sauce-connect-launcher.test.js
+++ b/test/sauce-connect-launcher.test.js
@@ -86,6 +86,17 @@ describe("Sauce Connect Launcher", function () {
     });
   });
 
+  it("fails with an invalid executable", function (done) {
+    var options = _.clone(sauceCreds);
+    options.exe = "not-found";
+
+    sauceConnectLauncher(options, function (err) {
+      expect(err).to.be.ok();
+      expect(err.message).to.contain("ENOENT");
+      done();
+    });
+  });
+
   if (sauceCreds) {
     it("should work with real credentials", function (done) {
       sauceConnectLauncher(sauceCreds, function (err, sauceConnectProcess) {


### PR DESCRIPTION
According to https://github.com/nodejs/LTS Node 0.10 has already reached
EOL and 0.12 will reach it soon.

Remove support for both versions.