### PR TITLE
Detached mode and configurable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ var sauceConnectLauncher = require('sauce-connect-launcher'),
     // path to a sauce connect executable (optional)
     // by default the latest sauce connect version is downloaded
     exe: null
+
+    // keep sc running after the node process exited, this means you need to close
+    // the process manually once you are done using the pidfile
+    // Attention: This only works with sc versions <= 4.3.16 and only on macOS and
+    // linux at the moment
+    detached: null
+
+    // specify a connect version instead of fetching the latest version, this currently
+    // does not support checksum verification
+    connectVersion: 'latest'
   };
 
 sauceConnectLauncher(options, function (err, sauceConnectProcess) {

--- a/lib/process_options.js
+++ b/lib/process_options.js
@@ -17,7 +17,7 @@ module.exports = function processOptions(options) {
   options.accessKey = options.accessKey || process.env.SAUCE_ACCESS_KEY;
 
   return _.reduce(
-    _.omit(options, ["readyFileId", "verbose", "logger", "log", "connectRetries", "connectRetryTimeout"]),
+    _.omit(options, ["readyFileId", "verbose", "logger", "log", "connectRetries", "connectRetryTimeout", "detached", "connectVersion"]),
     function (argList, value, key) {
       if (value == null) {
         return argList;

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -12,8 +12,6 @@ var
   exec = require("child_process").exec,
   crypto = require("crypto"),
   processOptions = require("./process_options"),
-  versionsfile,
-  archivefile,
   scDir = path.normalize(__dirname + "/../sc"),
   exists = fs.existsSync || path.existsSync,
   currentTunnel,
@@ -21,7 +19,6 @@ var
   cleanup_registered = false,
   sc_version = process.env.SAUCE_CONNECT_VERSION ||
     require("../package.json").sauceConnectLauncher.scVersion,
-  sc_checksum,
   tunnelIdRegExp = /Tunnel ID:\s*([a-z0-9]+)/i,
   portRegExp = /port\s*([0-9]+)/i,
   tryRun = require("./try_run");
@@ -53,23 +50,23 @@ function clean(callback) {
   ], callback);
 }
 
-function getArchiveName() {
+function getScFolderName(version) {
   return {
-    darwin: "sc-" + sc_version + "-osx.zip",
-    win32: "sc-" + sc_version + "-win32.zip"
-  }[process.platform] || "sc-" + sc_version + "-linux.tar.gz";
+    darwin: "sc-" + version + "-osx",
+    win32: "sc-" + version + "-win32"
+  }[process.platform] || "sc-" + version + "-linux";
 }
 
-function getScFolderName() {
-  return {
-    darwin: "sc-" + sc_version + "-osx",
-    win32: "sc-" + sc_version + "-win32"
-  }[process.platform] || "sc-" + sc_version + "-linux";
+function getArchiveName(version) {
+  return getScFolderName(version) + ({
+    darwin: ".zip",
+    win32: ".zip"
+  }[process.platform] || ".tar.gz");
 }
 
-function getScBin() {
+function getScBin(version) {
   var exe = process.platform === "win32" ? ".exe" : "";
-  return path.normalize(scDir + "/" + getScFolderName() + "/bin/sc" + exe);
+  return path.normalize(scDir + "/" + getScFolderName(version) + "/bin/sc" + exe);
 }
 
 // Make sure all processes have been closed
@@ -85,39 +82,51 @@ function closeOnProcessTermination() {
   });
 }
 
-function unpackArchive(callback) {
-  logger("Unzipping " + getArchiveName());
+function unpackArchive(archivefile, callback) {
+  logger("Unzipping " + archivefile);
+
+  function done(err) {
+    if (err) { return callback(new Error("Couldn't unpack archive: " + err.message)); }
+    // write queued data before closing the stream
+    logger("Removing " + archivefile);
+    fs.unlinkSync(archivefile);
+    logger("Sauce Connect downloaded correctly");
+
+    callback();
+  }
+
   setTimeout(function () {
     if (archivefile.match(/\.tar\.gz$/)) {
-      exec("tar -xzf '" + archivefile + "'", {cwd: scDir}, callback);
+      exec("tar -xzf '" + archivefile + "'", {cwd: scDir}, done);
     } else {
       try {
         var zip = new AdmZip(archivefile);
         zip.extractAllTo(scDir, true);
       } catch (e) {
-        return callback(new Error("ERROR Unzipping file: ", e.message));
+        return done(new Error("ERROR Unzipping file: " + e.message));
       }
-      callback(null);
+
+      done();
     }
   }, 1000);
 }
 
-function setExecutePermissions(callback) {
+function setExecutePermissions(bin, callback) {
   if (os.type() === "Windows_NT") {
     // No need to set permission for the executable on Windows
-    callback(null);
+    callback(null, bin);
   } else {
     // check current permissions
-    fs.stat(getScBin(), function (err, stat) {
+    fs.stat(bin, function (err, stat) {
       if (err) { return callback(new Error("Couldn't read sc permissions: " + err.message)); }
 
       if (stat.mode.toString(8) !== "100755") {
-        fs.chmod(getScBin(), 0755, function (err) {
+        fs.chmod(bin, 0755, function (err) {
           if (err) { return callback(new Error("Couldn't set permissions: " + err.message)); }
-          callback(null);
+          callback(null, bin);
         });
       } else {
-        callback(null);
+        callback(null, bin);
       }
     });
   }
@@ -139,31 +148,40 @@ function httpsRequest(options) {
   return https.request(options);
 }
 
-function verifyChecksum(cb) {
+function verifyChecksum(archivefile, checksum, cb) {
+  if (!checksum) {
+    logger("Checksum check for manually overwritten sc version isn't supported.");
+    return cb();
+  }
+
   var fd = fs.createReadStream(archivefile);
   var hash = crypto.createHash("sha1");
   hash.setEncoding("hex");
 
-  hash.on("end", function() {
-    hash.end();
-
+  hash.on("finish", function() {
     var sha1 = hash.read();
-    if (sha1 !== sc_checksum) {
-      cb(new Error("Checksum of the downloaded archive (" + sha1 + ") doesn't match (" + sc_checksum + ")."));
+    if (sha1 !== checksum) {
+      return cb(new Error("Checksum of the downloaded archive (" + sha1 + ") doesn't match (" + checksum + ")."));
     }
 
+    logger("Archive checksum verified.");
+
     cb();
+  });
+
+  hash.on("error", function (err) {
+    cb(err);
   });
 
   fd.pipe(hash);
 }
 
-function fetchAndUnpack(options, callback) {
+function fetchArchive(archiveName, archivefile, callback) {
   var req = httpsRequest({
-      host: "saucelabs.com",
-      port: 443,
-      path: "/downloads/" + getArchiveName()
-    });
+    host: "saucelabs.com",
+    port: 443,
+    path: "/downloads/" + archiveName
+  });
 
   function removeArchive() {
     try {
@@ -189,34 +207,60 @@ function fetchAndUnpack(options, callback) {
     res.pipe(fs.createWriteStream(archivefile));
 
     // cleanup if the process gets interrupted.
-    process.on("exit", removeArchive);
-    process.on("SIGHUP", removeArchive);
-    process.on("SIGINT", removeArchive);
-    process.on("SIGTERM", removeArchive);
-
-    function done(err) {
-      if (err) { return callback(new Error("Couldn't unpack archive: " + err.message)); }
-      // write queued data before closing the stream
-      logger("Removing " + getArchiveName());
-      fs.unlinkSync(archivefile);
-      logger("Sauce Connect downloaded correctly");
-      callback(null);
-    }
+    var events = ["exit", "SIGHUP", "SIGINT", "SIGTERM"];
+    events.forEach(function (event) {
+      process.on(event, removeArchive);
+    });
 
     res.on("end", function () {
-      if (sc_checksum) {
-        async.waterfall([
-          async.apply(verifyChecksum),
-          async.apply(unpackArchive),
-        ], done);
-      }
+      events.forEach(function (event) {
+        process.removeListener(event, removeArchive);
+      });
 
-      unpackArchive(done);
+      callback();
     });
 
   });
 
   req.end();
+}
+
+function fetchAndCheckArchive(archiveName, archivefile, checksum, callback) {
+  return async.waterfall([
+    async.apply(fetchArchive, archiveName, archivefile),
+    async.apply(verifyChecksum, archivefile, checksum)
+  ], callback);
+}
+
+function unpackAndFixArchive(archivefile, bin, callback) {
+  return async.waterfall([
+    async.apply(unpackArchive, archivefile),
+    async.apply(setExecutePermissions, bin)
+  ], callback);
+}
+
+function fetchAndUnpackArchive(versionDetails, options, callback) {
+  var bin = getScBin(versionDetails.version);
+  if (exists(bin)) {
+    return callback(null, bin);
+  }
+
+  var archiveName = getArchiveName(versionDetails.version);
+  var archivefile = path.normalize(scDir + "/" + archiveName);
+
+  if (exists(archivefile)) {
+    // the archive is being downloaded, poll for the binary to be ready
+    async.doUntil(function wait(cb) {
+      _.delay(cb, 1000);
+    }, async.apply(exists, bin), function () {
+      callback(null, bin);
+    });
+  }
+
+  async.waterfall([
+    async.apply(fetchAndCheckArchive, archiveName, archivefile, versionDetails.checksum),
+    async.apply(unpackAndFixArchive, archivefile, bin)
+  ], callback);
 }
 
 function scPlatform() {
@@ -226,27 +270,36 @@ function scPlatform() {
   }[process.platform] || "linux";
 }
 
-function getVersions(cb) {
-  function done(err) {
-    if (err) {
-      return cb(err);
-    }
+function readVersionsFile(versionsfile, cb) {
+  var versions = require(versionsfile)["Sauce Connect"];
 
-    var versions = require(versionsfile)["Sauce Connect"];
+  return cb(null, {
+    version: versions["version"],
+    checksum: versions[scPlatform()]["sha1"]
+  });
+}
 
-    sc_version = versions["version"];
-    sc_checksum = versions[scPlatform()]["sha1"];
-
-    return cb();
+function getVersion(options, cb) {
+  if (options.connectVersion) {
+    return cb(null, {
+      version: options.connectVersion
+    });
   }
-
   if (sc_version !== "latest") {
     logger("Checksum check for manually overwritten sc versions isn't supported.");
-    return done();
+    return cb(null, {
+      version: sc_version
+    });
   }
 
+  var versionsfile = path.normalize(scDir + "/versions.json");
+
   if (exists(versionsfile)) {
-    return done();
+    return readVersionsFile(versionsfile, cb);
+  }
+
+  if (!fs.existsSync(scDir)) {
+    fs.mkdirSync(scDir);
   }
 
   var req = httpsRequest({
@@ -257,7 +310,7 @@ function getVersions(cb) {
 
   req.on("response", function (res) {
     if (res.statusCode !== 200) {
-      return done(new Error("Fetching https://saucelabs.com/versions.json failed: " + res.statusCode));
+      return cb(new Error("Fetching https://saucelabs.com/versions.json failed: " + res.statusCode));
     }
 
     var file = fs.createWriteStream(versionsfile);
@@ -265,11 +318,11 @@ function getVersions(cb) {
     res.pipe(file);
 
     file.on("error", function (err) {
-      done(err);
+      cb(err);
     });
 
     file.on("close", function () {
-      done();
+      readVersionsFile(versionsfile, cb);
     });
 
   });
@@ -282,49 +335,38 @@ function download(options, callback) {
     callback = options;
     options = {};
   }
-  logger = options.logger || function () {};
 
   if (options.exe) {
-    return callback(null);
-  }
-
-  if (!fs.existsSync(scDir)) {
-    fs.mkdirSync(scDir);
-  }
-
-  function checkForArchive(next) {
-    if (!exists(archivefile)) {
-      fetchAndUnpack(options, next);
-    } else {
-      // the zip is being downloaded, poll for the binary to be ready
-      async.doUntil(function wait(cb) {
-        _.delay(cb, 1000);
-      }, async.apply(exists, getScBin()), next);
-    }
+    return callback(null, options.exe);
   }
 
   async.waterfall([
-    getVersions,
-    function checkForBinary(next) {
-      if (exists(getScBin())) {
-        next(null);
-      } else {
-        checkForArchive(next);
-      }
-    },
-    async.apply(setExecutePermissions),
+    async.apply(getVersion, options),
+    function (versionDetails, next) {
+      return fetchAndUnpackArchive(versionDetails, options, next);
+    }
   ], callback);
 }
 
-function connect(options, callback) {
+function connect(bin, options, callback) {
   var child;
   var logger = options.logger || function () {};
-  callback = _.once(callback);
+  var starting = true;
+  var done = function (err, child) {
+    if (!starting) {
+      return;
+    }
+    starting = false;
+    callback(err, child);
+  };
 
   function ready() {
     logger("Testing tunnel ready");
-    closeOnProcessTermination();
-    callback(null, child);
+
+    if (!options.detached) {
+      closeOnProcessTermination();
+    }
+    done(null, child);
   }
 
   logger("Opening local tunnel using Sauce Connect");
@@ -370,10 +412,7 @@ function connect(options, callback) {
       "Error: ": handleError,
       "Error bringing": handleError,
       "Sauce Connect could not establish a connection": handleError,
-      "{\"error\":": handleError,
-      "Goodbye.": function shutDown() {
-
-      }
+      "{\"error\":": handleError
   },
   previousData = "",
   killProcessTimeout = null,
@@ -404,7 +443,7 @@ function connect(options, callback) {
     });
   });
 
-  watcher.on("error", callback);
+  watcher.on("error", done);
 
   logger("Starting sc with args: " + args
     .join(" ")
@@ -413,14 +452,13 @@ function connect(options, callback) {
     .replace(/[0-9a-f]{8}\-([0-9a-f]{4}\-){3}[0-9a-f]{12}/i,
       "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX"));
 
-  var exe;
-  if (options.exe) {
-    exe = options.exe;
-  } else {
-    exe = getScBin();
+  var spawnOptions = {};
+
+  if (options.detached) {
+    spawnOptions.detached = true;
   }
 
-  child = spawn(exe, args);
+  child = spawn(bin, args, spawnOptions);
 
   currentTunnel = child;
 
@@ -437,6 +475,10 @@ function connect(options, callback) {
       if (options.verbose) {
         logger(line);
       }
+
+      if (!starting) {
+        return;
+      }
       _.each(dataActions, function (action, key) {
         if (line.indexOf(key) !== -1) {
           action(line);
@@ -446,11 +488,21 @@ function connect(options, callback) {
     });
   });
 
+  child.stderr.on("data", function (data) {
+    var line = data.toString().trim();
+    if (line === "") {
+      return;
+    }
+    if (options.verbose) {
+      logger(line);
+    }
+  });
+
   child.on("error", function (err) {
     logger("Sauce connect process errored: " + err);
 
     fs.unwatchFile(readyfile);
-    return callback(err);
+    return done(err);
   });
 
   child.on("exit", function (code, signal) {
@@ -464,14 +516,14 @@ function connect(options, callback) {
     fs.unwatchFile(readyfile);
 
     if (error) { // from handleError() above
-      return callback(error);
+      return done(error);
     }
 
     var message = "Closing Sauce Connect Tunnel";
     if (code > 0) {
       message = "Could not start Sauce Connect. Exit code " + code +
         " signal: " + signal;
-      callback(new Error(message));
+      done(new Error(message));
     }
     logger(message);
   });
@@ -505,11 +557,10 @@ function connect(options, callback) {
   };
 }
 
-
-
-
-function run(options, callback) {
-  tryRun(0, options, connect, callback);
+function run(version, options, callback) {
+  tryRun(0, options, function (tryCallback) {
+    return connect(version, options, tryCallback);
+  }, callback);
 }
 
 function downloadAndRun(options, callback) {
@@ -521,16 +572,14 @@ function downloadAndRun(options, callback) {
 
   async.waterfall([
     async.apply(download, options),
-    async.apply(run, options),
+    function (bin, next) {
+      return run(bin, options, next);
+    },
   ], callback);
 }
-
-versionsfile = path.normalize(scDir + "/versions.json");
-archivefile = path.normalize(scDir + "/" + getArchiveName());
 
 module.exports = downloadAndRun;
 module.exports.download = download;
 module.exports.kill = killProcesses;
-module.exports.getArchiveName = getArchiveName;
 module.exports.clean = clean;
 module.exports.setWorkDir = setWorkDir;

--- a/lib/try_run.js
+++ b/lib/try_run.js
@@ -1,7 +1,7 @@
 var defaultConnectRetryTimeout = 2000;
 
 module.exports = function tryRun(count, options, fn, callback) {
-  fn(options, function (err, result) {
+  fn(function (err, result) {
     if (err) {
       if (count < options.connectRetries) {
         return setTimeout(function () {

--- a/test/fixture/spawn-sc.js
+++ b/test/fixture/spawn-sc.js
@@ -1,0 +1,12 @@
+var sauceConnectLauncher = require("../../index");
+var options = JSON.parse(process.argv[2]);
+
+options.logger = console.log;
+
+sauceConnectLauncher(options, function (err)  {
+  if (err) {
+    throw err;
+  }
+
+  process.exit(0);
+});

--- a/test/process_options.test.js
+++ b/test/process_options.test.js
@@ -66,7 +66,9 @@ describe("processOptions", function () {
       verbose: true,
       logger: function () {},
       connectRetries: 1,
-      connectRetryTimeout: 5000
+      connectRetryTimeout: 5000,
+      detached: true,
+      connectVersion: "1.2.3"
     })).to.eql([]);
   });
 

--- a/test/try_run_test.js
+++ b/test/try_run_test.js
@@ -7,7 +7,7 @@ describe("tryRun", function () {
   describe("without configured retry", function () {
     it("calls the provided function once", function (done) {
       var innerCalls = 0;
-      tryRun(0, {}, function (options, callback) {
+      tryRun(0, {}, function (callback) {
         innerCalls += 1;
         callback(innerErr);
       }, function (err) {
@@ -26,7 +26,7 @@ describe("tryRun", function () {
 
     it("calls the provided function once when no error is returned", function (done) {
       var innerCalls = 0;
-      tryRun(0, retryOptions, function (options, callback) {
+      tryRun(0, retryOptions, function (callback) {
         innerCalls += 1;
         callback(null);
       }, function (err) {
@@ -38,7 +38,7 @@ describe("tryRun", function () {
 
     it("retries up-to connectRetries when the function returns an error", function (done) {
       var innerCalls = 0;
-      tryRun(0, retryOptions, function (options, callback) {
+      tryRun(0, retryOptions, function (callback) {
         innerCalls += 1;
         callback(innerErr);
       }, function (err) {
@@ -51,7 +51,7 @@ describe("tryRun", function () {
     it("waits connectRetryTimeout between retries", function (done) {
       var innerCalls = 0;
       var start = Date.now();
-      tryRun(0, retryOptions, function (options, callback) {
+      tryRun(0, retryOptions, function (callback) {
         innerCalls += 1;
         callback(innerErr);
       }, function () {


### PR DESCRIPTION
Allow to run sc in detached mode and to specify a connectVersion when downloading and creating the tunnel.

There are various changes in the code to remove the global version and resolve a local version inside the function to allow running multiple versions in parallel and prevent misleading checksum errors once the latest version has been resolved.

Fixes version overriding using `SAUCE_CONNECT_VERSION`.

Replaces: https://github.com/bermi/sauce-connect-launcher/pull/104
Fixes: https://github.com/bermi/sauce-connect-launcher/issues/106