### PR TITLE
Fix creating sc directory with a custom version set

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,10 +23,5 @@
   "onevar": true,
   "white": true,
   "strict": false,
-  "globals": {
-    "describe": true,
-    "after": true,
-    "before": true,
-    "it": true
-  }
+  "mocha": true
 }

--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -177,6 +177,10 @@ function verifyChecksum(archivefile, checksum, cb) {
 }
 
 function fetchArchive(archiveName, archivefile, callback) {
+  if (!fs.existsSync(scDir)) {
+    fs.mkdirSync(scDir);
+  }
+
   var req = httpsRequest({
     host: "saucelabs.com",
     port: 443,

--- a/test/sauce-connect-launcher.test.js
+++ b/test/sauce-connect-launcher.test.js
@@ -54,6 +54,10 @@ describe("Sauce Connect Launcher", function () {
 
   beforeEach(removeSauceConnect);
 
+  afterEach(function (done) {
+    sauceConnectLauncher.kill(done);
+  });
+
   this.timeout(3600 * 10000);
 
   it("fails with an invalid executable", function (done) {
@@ -112,7 +116,7 @@ describe("Sauce Connect Launcher", function () {
   if (sauceCreds) {
     it("should work with real credentials", function (done) {
       sauceConnectLauncher(sauceCreds, function (err, sauceConnectProcess) {
-        if (err) { throw err; }
+        expect(err).to.not.be.ok();
         expect(sauceConnectProcess).to.be.ok();
         sauceConnectLauncher.kill();
         expect(sauceCreds.log).to.contain("Testing tunnel ready", "Closing Sauce Connect Tunnel");
@@ -124,7 +128,7 @@ describe("Sauce Connect Launcher", function () {
 
     it("should execute a provided close callback", function (done) {
       sauceConnectLauncher(sauceCreds, function (err, sauceConnectProcess) {
-        if (err) { throw err; }
+        expect(err).to.not.be.ok();
         expect(sauceConnectProcess).to.be.ok();
         sauceConnectProcess.close(function () {
           done();
@@ -134,7 +138,7 @@ describe("Sauce Connect Launcher", function () {
 
     it("closes the open tunnel", function (done) {
       sauceConnectLauncher(sauceCreds, function (err, sauceConnectProcess) {
-        if (err) { throw err; }
+        expect(err).to.not.be.ok();
         expect(sauceConnectProcess).to.be.ok();
         expect(sauceConnectProcess.tunnelId).to.be.ok();
 

--- a/test/sauce-connect-launcher.test.js
+++ b/test/sauce-connect-launcher.test.js
@@ -52,8 +52,7 @@ describe("Sauce Connect Launcher", function () {
     rimraf(path.normalize(__dirname + "/../sc/"), done);
   };
 
-  before(removeSauceConnect);
-  //after(removeSauceConnect);
+  beforeEach(removeSauceConnect);
 
   this.timeout(3600 * 10000);
 


### PR DESCRIPTION
The sc dir was previously only created when the version file was fetched,
which is not done when a custom version is provided.

Also change the tests to remove the sc file before each test to ensure
the bootstrapping always works.