### PR TITLE
Catch 'ERROR:' messages from SC binary

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -414,6 +414,7 @@ function connect(bin, options, callback) {
 
       },
       "Error: ": handleError,
+      "ERROR: ": handleError,
       "Error bringing": handleError,
       "Sauce Connect could not establish a connection": handleError,
       "{\"error\":": handleError


### PR DESCRIPTION
This was an error I was hitting where sc was outputting:

    ERROR: can't open pidfile /tmp/sc_client-<name >/1479705594315.pid