### PR TITLE
Add handling for single-letter uppercase-only SauceConnect flags

### DIFF
--- a/lib/process_options.js
+++ b/lib/process_options.js
@@ -36,7 +36,7 @@ module.exports = function processOptions(options) {
       if (typeof value === "undefined" || value === null) {
         return argList;
       }
-      var argName = overrides[key] || _.kebabCase(key);
+      var argName = overrides[key] || ( key[0] !== "-" && key.length > 1 && _.kebabCase(key)) || key;
 
       if (argName.length === 1) {
         argName = "-" + argName;

--- a/test/process_options.test.js
+++ b/test/process_options.test.js
@@ -82,4 +82,20 @@ describe("processOptions", function () {
     expect(result).to.eql(["-vv"]);
   });
 
+  it("should handle single-letter flag without changing to kebab-case", function() {
+    var result = processOptions({
+      B: "all",
+      "-N": true
+    });
+    expect(result).to.eql(["-B", "all", "-N"]);
+  });
+
+  it("should pass flags starting with dash with no changes", function() {
+    var result = processOptions({
+      "-SomeOptionWithDash": true,
+      "--SomeOptionWithTwoDashes": "foo"
+    });
+    expect(result).to.eql(["-SomeOptionWithDash", "--SomeOptionWithTwoDashes", "foo"]);
+  });
+
 });


### PR DESCRIPTION
### What
Add handling for single-letter uppercase-only SauceConnect flags

### Why
Currently cannot pass "-B" for example, since it will get converted
to "-b" that SauceConnect does not recognize.

### Who
@johanneswuerbach @bermi 

### Context
https://wiki.saucelabs.com/pages/viewpage.action?pageId=48365781