### PR TITLE
Chore: bump https-proxy-agent to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "adm-zip": "~0.4.3",
     "async": "^2.1.2",
-    "https-proxy-agent": "~1.0.0",
+    "https-proxy-agent": "^2.2.1",
     "lodash": "^4.16.6",
     "rimraf": "^2.5.4"
   },


### PR DESCRIPTION
Bumps https-proxy-agent to 2.2.1, fixing an [uninitialized memory exposure issue](https://snyk.io/vuln/npm:https-proxy-agent:20180402). It's also the only outdated dependency in this module.

As far as I can tell from the commit log, the breaking change was [only supporting node >= 4](https://github.com/TooTallNate/node-https-proxy-agent/commit/bdad2dc4e9d5c53ecf7c6247af3a01f7957458c6). That's not a problem with this module, since it [also only supports node >= 4](https://github.com/bermi/sauce-connect-launcher/blob/master/package.json#L46).