### PR TITLE
Don't override custom -x

### DIFF
--- a/lib/sauce-connect-launcher.js
+++ b/lib/sauce-connect-launcher.js
@@ -465,7 +465,12 @@ function connect(bin, options, callback) {
     "/" + readyFileName);
 
   args.push("--readyfile", readyfile);
-  args.push("-x", `https://${SAUCE_API_HOST}/rest/v1`);
+
+  // Only add -x when it wasn't specified
+  var xArgIdx = args.findIndex((arg) => arg === "-x")
+  if (xArgIdx === -1) {
+    args.push("-x", `https://${SAUCE_API_HOST}/rest/v1`);
+  }
 
   // Watching file as directory watching does not work on
   // all File Systems http://nodejs.org/api/fs.html#fs_caveats


### PR DESCRIPTION
Allow custom `-x` option. 

Fixes https://github.com/bermi/sauce-connect-launcher/issues/143