### PR TITLE
remove check before daownloading Sauce Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ A library to download and launch Sauce Connect.
 npm install sauce-connect-launcher
 ```
 
-If you wish to also download Sauce Connect at this stage, rather than on first run, use the `SAUCE_CONNECT_DOWNLOAD_ON_INSTALL` environment variable.
-
-```sh
-SAUCE_CONNECT_DOWNLOAD_ON_INSTALL=true npm install
-```
-
 ## Usage
 
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,10 +1,5 @@
 "use strict";
 
-// Only download on install when requested.
-if (!process.env.SAUCE_CONNECT_DOWNLOAD_ON_INSTALL) {
-  return;
-}
-
 var sauceConnectLauncher = require("../");
 
 sauceConnectLauncher.download({


### PR DESCRIPTION
Removed the check before download Sauce Connect once the package is installed. 
It is more convenient when the plugin downloads all necessary files at once.