### PR TITLE
update https-proxy-agent dependency to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -775,11 +775,11 @@
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
       "requires": {
-        "es6-promisify": "^5.0.0"
+        "debug": "4"
       }
     },
     "ajv": {
@@ -864,7 +864,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1549,9 +1549,9 @@
       "dev": true
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1632,7 +1632,7 @@
     },
     "detect-newline": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/detect-newline/-/detect-newline-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
@@ -1753,19 +1753,6 @@
         "es6-set": "~0.1.5",
         "es6-symbol": "~3.1.1",
         "event-emitter": "~0.3.5"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "es6-set": {
@@ -2108,7 +2095,7 @@
     },
     "expect.js": {
       "version": "0.3.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/expect.js/-/expect.js-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
       "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
       "dev": true
     },
@@ -3106,7 +3093,7 @@
     },
     "growly": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/growly/-/growly-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
@@ -3517,12 +3504,12 @@
       }
     },
     "https-proxy-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
-      "integrity": "sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "iconv-lite": {
@@ -3820,7 +3807,7 @@
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
@@ -5101,7 +5088,7 @@
     },
     "load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/load-json-file/-/load-json-file-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
@@ -5204,7 +5191,7 @@
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
@@ -5243,7 +5230,7 @@
     },
     "makeerror": {
       "version": "1.0.11",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/makeerror/-/makeerror-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
@@ -5515,13 +5502,13 @@
     },
     "node-int64": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-modules-regexp": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
       "dev": true
     },
@@ -5603,7 +5590,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -5779,7 +5766,7 @@
     },
     "p-each-series": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-each-series/-/p-each-series-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
@@ -5818,7 +5805,7 @@
     },
     "p-reduce": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-reduce/-/p-reduce-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
     },
@@ -5830,7 +5817,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -5896,7 +5883,7 @@
     },
     "pify": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
@@ -6041,7 +6028,7 @@
     },
     "read-pkg": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/read-pkg/-/read-pkg-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
@@ -6133,7 +6120,7 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
@@ -6268,7 +6255,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -6277,7 +6264,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -6751,13 +6738,13 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "string-length": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-length/-/string-length-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
@@ -6767,13 +6754,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -6974,7 +6961,7 @@
     },
     "throat": {
       "version": "4.1.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/throat/-/throat-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
@@ -7006,13 +6993,13 @@
     },
     "tmpl": {
       "version": "1.0.4",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tmpl/-/tmpl-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
@@ -7070,7 +7057,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -7287,7 +7274,7 @@
     },
     "walker": {
       "version": "1.0.7",
-      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/walker/-/walker-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "adm-zip": "~0.4.3",
     "async": "^2.1.2",
-    "https-proxy-agent": "^3.0.0",
+    "https-proxy-agent": "^5.0.0",
     "lodash": "^4.16.6",
     "rimraf": "^2.5.4"
   },


### PR DESCRIPTION
@johanneswuerbach Here we go... 🎉 

This pr tackles issue #155 

I don't know why the old package-lock was pointing to artifactory.skyscannertools.net instead of registry.npmjs.org so please let me know if this change would cause an issue.